### PR TITLE
Parsistent storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "@popperjs/core": "^2.11.7",
         "classnames": "^2.3.2",
         "flowbite": "^1.6.5",
-        "flowbite-svelte": "^0.34.10"
+        "flowbite-svelte": "^0.34.10",
+        "idb": "^7.1.1"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.1.1",
@@ -2245,6 +2246,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "node_modules/ignore": {
       "version": "5.2.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@popperjs/core": "^2.11.7",
     "classnames": "^2.3.2",
     "flowbite": "^1.6.5",
-    "flowbite-svelte": "^0.34.10"
+    "flowbite-svelte": "^0.34.10",
+    "idb": "^7.1.1"
   }
 }

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -1,0 +1,53 @@
+//
+// AppContext.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import type { MoltonfDB } from "./lib/storage/MoltonfDB"
+import type { IDBPDatabase } from "idb"
+import { StoryStore } from "./lib/storage/StoryStore"
+import { openMoltonfDB } from "./lib/storage/MoltonfDB"
+
+export class AppContext {
+  static Key = Symbol()
+  
+  private _dbPromise: Promise<IDBPDatabase<MoltonfDB> | undefined>
+  
+  constructor() {
+    this._dbPromise = Promise.resolve(undefined)
+  }
+
+  private async readyDB(): Promise<IDBPDatabase<MoltonfDB>> {
+    const db = await this._dbPromise
+    if (db !== undefined) {
+      return db
+    }
+    
+    const dbPromise = openMoltonfDB()
+    this._dbPromise = dbPromise
+    return await dbPromise
+  }
+  
+  async getStoryStore(): Promise<StoryStore> {
+    return new StoryStore(await this.readyDB())
+  }
+}

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -26,6 +26,7 @@ import type { MoltonfDB } from "./lib/storage/MoltonfDB"
 import type { IDBPDatabase } from "idb"
 import { StoryStore } from "./lib/storage/StoryStore"
 import { openMoltonfDB } from "./lib/storage/MoltonfDB"
+import { WorkspaceStore } from "./lib/storage/WorkspaceStore"
 
 export class AppContext {
   static Key = Symbol()
@@ -49,5 +50,9 @@ export class AppContext {
   
   async getStoryStore(): Promise<StoryStore> {
     return new StoryStore(await this.readyDB())
+  }
+  
+  async getWorkspaceStore(): Promise<WorkspaceStore> {
+    return new WorkspaceStore(await this.readyDB())
   }
 }

--- a/src/lib/storage/MoltonfDB.ts
+++ b/src/lib/storage/MoltonfDB.ts
@@ -1,0 +1,54 @@
+//
+// MoltonfDB.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import type { DBSchema, IDBPDatabase } from "idb"
+import type { Story } from "../story/Story"
+import { openDB } from "idb"
+import type { StoryEntry } from "./StoryStore"
+
+export const StoreNames = {
+  STORIES: "stories",
+  STORY_ENTRIES: "storyEntries"
+} as const
+
+export interface MoltonfDB extends DBSchema {
+  stories: {
+    key: number
+    value: Story
+  }
+
+  storyEntries: {
+    key: number
+    value: StoryEntry
+  }
+}
+
+export async function openMoltonfDB(): Promise<IDBPDatabase<MoltonfDB>> {
+  return await openDB<MoltonfDB>("moltonf-db", 1, {
+    upgrade(database: IDBPDatabase<MoltonfDB>) {
+      database.createObjectStore(StoreNames.STORIES, { autoIncrement: true })
+      database.createObjectStore(StoreNames.STORY_ENTRIES, { keyPath: "id" })
+    }
+  })
+}

--- a/src/lib/storage/StoryStore.ts
+++ b/src/lib/storage/StoryStore.ts
@@ -1,0 +1,83 @@
+//
+// StoryStore.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import type { IDBPDatabase } from "idb"
+import type { MoltonfDB } from "./MoltonfDB"
+import type { Story } from "../story/Story"
+import { StoreNames } from "./MoltonfDB"
+
+/**
+ * Storage for stories.
+ * 
+ * Stories are saved in IndexedDB.
+ */
+export class StoryStore {
+  private _db: IDBPDatabase<MoltonfDB>
+
+  constructor(db: IDBPDatabase<MoltonfDB>) {
+    this._db = db
+  }
+  
+  async add(story: Story) {
+    const tx = this._db.transaction([StoreNames.STORIES, StoreNames.STORY_ENTRIES], "readwrite")
+    const storiesStore = tx.objectStore(StoreNames.STORIES)
+    const storyNamesStore = tx.objectStore(StoreNames.STORY_ENTRIES)
+    const key = await storiesStore.add(story)
+    await storyNamesStore.put({
+      id: key,
+      name: story.villageFullName,
+    })
+    await tx.done
+  }
+  
+  async remove(id: number) {
+    const tx = this._db.transaction([StoreNames.STORIES, StoreNames.STORY_ENTRIES], "readwrite")
+    const storiesStore = tx.objectStore(StoreNames.STORIES)
+    const storyNamesStore = tx.objectStore(StoreNames.STORY_ENTRIES)
+    await storiesStore.delete(id)
+    await storyNamesStore.delete(id)
+    await tx.done
+  }
+  
+  async getEntries(): Promise<StoryEntry[]> {
+    const result: StoryEntry[] = []
+    const tx = this._db.transaction(StoreNames.STORY_ENTRIES)
+    let cursor = await tx.store.openCursor()
+    while (cursor !== null) {
+      result.push(cursor.value)
+      cursor = await cursor.continue()
+    }
+    return result
+  }
+  
+  async getStory(id: number): Promise<Story | undefined> {
+    const tx = this._db.transaction(StoreNames.STORIES)
+    return await tx.store.get(id)
+  }
+}
+
+export interface StoryEntry {
+  id: number
+  name: string
+}

--- a/src/lib/storage/WorkspaceStore.ts
+++ b/src/lib/storage/WorkspaceStore.ts
@@ -41,8 +41,8 @@ export class WorkspaceStore {
 
   async add(workspace: Omit<Workspace, "id">): Promise<number> {
     const tx = this._db.transaction(StoreNames.WORKSPACES, "readwrite")
-    // @ts-ignore It's OK to omit id because it is created by "autoIncrement"
-    const key = await tx.store.add(workspace)
+    // It's OK to omit id because it is created by "autoIncrement"
+    const key = await tx.store.add(workspace as Workspace)
     await tx.done
     return key
   }

--- a/src/lib/workspace/Workspace.ts
+++ b/src/lib/workspace/Workspace.ts
@@ -1,5 +1,5 @@
 //
-// MoltonfDB.ts
+// Workspace.ts
 //
 // Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
 //
@@ -22,41 +22,9 @@
 // THE SOFTWARE.
 //
 
-import type { DBSchema, IDBPDatabase } from "idb"
-import type { Story } from "../story/Story"
-import { openDB } from "idb"
-import type { StoryEntry } from "./StoryStore"
-import type { Workspace } from "../workspace/Workspace"
-
-export const StoreNames = {
-  STORIES: "stories",
-  STORY_ENTRIES: "storyEntries",
-  WORKSPACES: "workspaces",
-} as const
-
-export interface MoltonfDB extends DBSchema {
-  stories: {
-    key: number
-    value: Story
-  }
-
-  storyEntries: {
-    key: number
-    value: StoryEntry
-  }
-  
-  workspaces: {
-    key: number
-    value: Workspace
-  }
-}
-
-export async function openMoltonfDB(): Promise<IDBPDatabase<MoltonfDB>> {
-  return await openDB<MoltonfDB>("moltonf-db", 1, {
-    upgrade(database: IDBPDatabase<MoltonfDB>) {
-      database.createObjectStore(StoreNames.STORIES, { autoIncrement: true })
-      database.createObjectStore(StoreNames.STORY_ENTRIES, { keyPath: "id" })
-      database.createObjectStore(StoreNames.WORKSPACES, { keyPath: "id", autoIncrement: true })
-    }
-  })
+export interface Workspace {
+  id: number
+  name: string
+  storyId: number
+  // TODO: other stuff...
 }


### PR DESCRIPTION
Make it possible to store stories and workspaces in users local IndexedDB.

Note that stories are saved on two stores, named `StoreNames.STORIES` and `StoreNames.STORY_ENTRIES`. An entire story has a large amount of data and is not suitable for listing multiple ones at once, so we use `STORIES` for storing entire story data and `STORY_ENTRIES` for storing small data which suitable for listing.