### PR TITLE
Show public talk number

### DIFF
--- a/src/lib/scene/watching/StoryElementsView.svelte
+++ b/src/lib/scene/watching/StoryElementsView.svelte
@@ -63,6 +63,7 @@ THE SOFTWARE.
           avatarId: element.byWhom,
           xname: element.xname,
           time: element.time,
+          talkNo: undefined,
           messageLines: element.messageLines,
         }} avatarMap={$avatarMap$} faceIconUrlMap={$faceIconUrlMap$}/>
       {:else}

--- a/src/lib/scene/watching/TalkView.svelte
+++ b/src/lib/scene/watching/TalkView.svelte
@@ -39,6 +39,7 @@ THE SOFTWARE.
     avatarId: "",
     xname: "",
     time: 0,
+    talkNo: undefined,
     messageLines: []
   }
   
@@ -64,6 +65,9 @@ THE SOFTWARE.
 </script>
 
 <div>
+  {#if talk.talkNo !== undefined}
+    <span class="time">{talk.talkNo}.</span>
+  {/if}
   <span class="avatar-name">{avatar?.fullName}</span>
   <span class="time">{timeString(talk.time)}</span>
 </div>

--- a/src/lib/story/Archive.ts
+++ b/src/lib/story/Archive.ts
@@ -47,6 +47,7 @@ import type {
 import { EventFamilies } from "./EventFamily"
 import { EventNames } from "./StoryEventName"
 import type { Player } from "./Player"
+import { TalkTypes } from "./TalkType"
 
 export async function loadStoryFromArchiveFile(file: File): Promise<Story> {
   const xml = await readFileAsText(file)
@@ -87,6 +88,7 @@ function parseArciveDocument(document: XMLDocument): Story {
   let currentDay = 0
   let currentElementIndex = 0
   let currentElementId = ""
+  let publicTalkCount = 0
 
   function getAttribute(element: Element, name: string): string | undefined {
     return element.getAttribute(name) ?? undefined
@@ -347,7 +349,12 @@ function parseArciveDocument(document: XMLDocument): Story {
     const xname = getAttributeOrError(talkElem, "xname")
     const time = parseTime(getAttributeOrError(talkElem, "time"))
     const messageLines = parseMessageLines(talkElem)
-    
+
+    let talkNo: number | undefined = undefined
+    if (talkType === TalkTypes.PUBLIC) {
+      publicTalkCount++
+      talkNo = publicTalkCount
+    }
     return {
       elementId: currentElementId,
       elementType: StoryElementTypes.TALK,
@@ -355,6 +362,7 @@ function parseArciveDocument(document: XMLDocument): Story {
       avatarId,
       xname,
       time,
+      talkNo,
       messageLines,
     }
   }

--- a/src/lib/story/Talk.ts
+++ b/src/lib/story/Talk.ts
@@ -44,6 +44,9 @@ export interface Talk extends StoryElementBase {
   /** Time on which this talk is made (in milliseconds) */
   readonly time: number
   
+  /** Sequence number of public talk (only exists in public talk) */
+  readonly talkNo: number | undefined
+  
   /** Lines of messages */
   readonly messageLines: string[]
 }


### PR DESCRIPTION
Show a public talk number like country "G".

Example:
```
1188. 老人 モーリッツ 00:17
```

The number is generated in loading archived XML and is held on `Talk` stored in IndexedDB.
Existing data do not contain it so it is needed that reloading archived XML (and recreating workspace data). 