### PR TITLE
Change scene by URL location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
         "classnames": "^2.3.2",
         "flowbite": "^1.6.6",
         "flowbite-svelte": "^0.38.2",
-        "idb": "^7.1.1"
+        "idb": "^7.1.1",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.4.1",
         "@tsconfig/svelte": "^4.0.1",
+        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
         "autoprefixer": "^10.4.14",
@@ -679,6 +681,12 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3660,6 +3668,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "4.3.9",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^2.4.1",
     "@tsconfig/svelte": "^4.0.1",
+    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.59.11",
     "@typescript-eslint/parser": "^5.59.11",
     "autoprefixer": "^10.4.14",
@@ -42,6 +43,7 @@
     "classnames": "^2.3.2",
     "flowbite": "^1.6.6",
     "flowbite-svelte": "^0.38.2",
-    "idb": "^7.1.1"
+    "idb": "^7.1.1",
+    "uuid": "^9.0.0"
   }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 <script lang="ts">
   import { AppContext } from "./AppContext"
-  import { setContext } from "svelte"
+  import { onDestroy, setContext } from "svelte"
   import SelectWorkspace from "./lib/scene/select-workspace/SelectWorkspace.svelte"
   import NewWorkspace from "./lib/scene/new-workspace/NewWorkspace.svelte"
   import Watching from "./lib/scene/watching/Watching.svelte"
@@ -33,9 +33,16 @@ THE SOFTWARE.
   import { WatchingScene } from "./lib/scene/watching/WatchingScene"
   import MessageBox from "./lib/MessageBox.svelte"
   import NavBar from "./lib/NavBar.svelte"
+  import { HashHistory } from "./History"
+  import { InvalidScene } from "./lib/scene/invalid/InvalidScene"
+  import Invalid from "./lib/scene/invalid/Invalid.svelte"
 
-  const appContext = new AppContext()
+  const appContext = new AppContext(new HashHistory())
   setContext(AppContext.Key, appContext)
+
+  onDestroy(() => {
+    appContext.destroy()
+  })
 
   const scene$ = appContext.scene$
 </script>
@@ -50,6 +57,8 @@ THE SOFTWARE.
         <NewWorkspace/>
       {:else if $scene$ instanceof WatchingScene}
         <Watching/>
+      {:else if $scene$ instanceof InvalidScene}
+        <Invalid/>
       {/if}
     </div>
   </div>

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -31,18 +31,34 @@ import { derived, writable } from "svelte/store"
 import type { Scene } from "./Scene"
 import { SelectWorkspaceScene } from "./lib/scene/select-workspace/SelectWorkspaceScene"
 import type { ExtendedMessageBoxItem, MessageBoxItem } from "./lib/MessageBoxItem"
+import type { History, HistoryLocation } from "./History"
+import { currentValueWritable } from "./lib/CurrentValueStore"
+import { NewWorkspaceScene } from "./lib/scene/new-workspace/NewWorkspaceScene"
+import { WatchingScene } from "./lib/scene/watching/WatchingScene"
+import { InvalidScene } from "./lib/scene/invalid/InvalidScene"
+import { runDetached, unusedParameter } from "./lib/Utils"
 
 export class AppContext {
   static readonly Key = Symbol()
   
+  readonly history: History
+  private _unsubscribeHistoryLocation: () => void
   private _dbPromise: Promise<IDBPDatabase<MoltonfDB> | undefined>
-  private readonly _scene$ = writable<Scene>(new SelectWorkspaceScene(this))
+  private readonly _scene$ = currentValueWritable<Scene>(new SelectWorkspaceScene(this))
   private readonly _messageBoxItems$ = writable<ExtendedMessageBoxItem[]>([])
   
-  constructor() {
+  constructor(history: History) {
+    this.history = history
     this._dbPromise = Promise.resolve(undefined)
+    this._unsubscribeHistoryLocation = history.location$.subscribe(it => {
+      this.changeSceneByLocation(it.location)
+    })
   }
 
+  destroy() {
+    this._unsubscribeHistoryLocation()
+  }
+  
   //#region Scene
   
   get scene$(): Readable<Scene> { return this._scene$ }
@@ -51,11 +67,45 @@ export class AppContext {
   sceneAs$<T>(sceneClass: new (...args: any[]) => T): Readable<T | undefined> {
     return derived(this._scene$, it => (it instanceof sceneClass) ? it : undefined)
   }
-
-  changeScene(scene: Scene) {
-    this._scene$.set(scene)
-  }
   
+  private changeSceneByLocation(location: HistoryLocation) {
+    const currentScene = this._scene$.currentValue
+    const [first, second, ...remaining] = location.components
+    if (first !== "/") {
+      // Invalid
+      this._scene$.set(new InvalidScene(this, "Not Found"))
+    } else {
+      if (second === undefined) {
+        // Select Workspace
+        if (!(currentScene instanceof SelectWorkspaceScene)) {
+          this._scene$.set(new SelectWorkspaceScene(this))
+        }
+      } else if (second === "new") {
+        // New Workspace
+        if (!(currentScene instanceof NewWorkspaceScene)) {
+          this._scene$.set(new NewWorkspaceScene(this))
+        }
+      } else {
+        // Watching
+        const workspaceId = second
+        if (currentScene instanceof WatchingScene && currentScene.workspace.id === workspaceId) {
+          // TODO: currentScene.updateLocation(remaining)
+          unusedParameter(remaining)
+        } else {
+          runDetached(async () => {
+            const workspaceStore = await this.getWorkspaceStore()
+            const workspace = await workspaceStore.getWorkspace(workspaceId)
+            if (workspace === undefined) {
+              this._scene$.set(new InvalidScene(this, "観戦データが見つかりません。"))
+            } else {
+              this._scene$.set(new WatchingScene(this, workspace))
+            }
+          })
+        }
+      }
+    }
+  }
+
   //#endregion
 
   //#region Message box

--- a/src/AppContext.ts
+++ b/src/AppContext.ts
@@ -31,12 +31,13 @@ import { derived, writable } from "svelte/store"
 import type { Scene } from "./Scene"
 import { SelectWorkspaceScene } from "./lib/scene/select-workspace/SelectWorkspaceScene"
 import type { ExtendedMessageBoxItem, MessageBoxItem } from "./lib/MessageBoxItem"
-import type { History, HistoryLocation } from "./History"
+import type { History } from "./History"
+import { HistoryLocation } from "./History"
 import { currentValueWritable } from "./lib/CurrentValueStore"
 import { NewWorkspaceScene } from "./lib/scene/new-workspace/NewWorkspaceScene"
 import { WatchingScene } from "./lib/scene/watching/WatchingScene"
 import { InvalidScene } from "./lib/scene/invalid/InvalidScene"
-import { runDetached, unusedParameter } from "./lib/Utils"
+import { runDetached } from "./lib/Utils"
 
 export class AppContext {
   static readonly Key = Symbol()
@@ -70,7 +71,7 @@ export class AppContext {
   
   private changeSceneByLocation(location: HistoryLocation) {
     const currentScene = this._scene$.currentValue
-    const [first, second, ...remaining] = location.components
+    const [first, second] = location.components
     if (first !== "/") {
       // Invalid
       this._scene$.set(new InvalidScene(this, "Not Found"))
@@ -89,8 +90,7 @@ export class AppContext {
         // Watching
         const workspaceId = second
         if (currentScene instanceof WatchingScene && currentScene.workspace.id === workspaceId) {
-          // TODO: currentScene.updateLocation(remaining)
-          unusedParameter(remaining)
+          currentScene.updateLocation(location)
         } else {
           runDetached(async () => {
             const workspaceStore = await this.getWorkspaceStore()
@@ -98,7 +98,7 @@ export class AppContext {
             if (workspace === undefined) {
               this._scene$.set(new InvalidScene(this, "観戦データが見つかりません。"))
             } else {
-              this._scene$.set(new WatchingScene(this, workspace))
+              this._scene$.set(new WatchingScene(this, workspace, location))
             }
           })
         }

--- a/src/History.ts
+++ b/src/History.ts
@@ -1,0 +1,118 @@
+//
+// History.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+import type { Readable } from "svelte/store"
+import { writable } from "svelte/store"
+import { v4 as uuidv4 } from 'uuid'
+
+export class HistoryLocation {
+  readonly path: string
+  readonly components: string[]
+
+  private constructor(path: string, components: string[]) {
+    this.path = path
+    this.components = components
+  }
+
+  static fromPath(path: string): HistoryLocation {
+    const components0 = path
+      .replace(/(^\/+|\/+$)/g, "") // remove leading and trailing slashes
+      .split("/")
+      .map(it => decodeURIComponent(it))
+    const components1 = (components0.length === 1 && components0[0] === "") ? [] : components0
+    const components = (path.startsWith("/")) ? ["/", ...components1] : components1
+    return new HistoryLocation(path, components)
+  }
+
+  static fromComponents(components: string[]): HistoryLocation {
+    const [first, ...remaining] = components
+    const path = (first === "/") 
+      ? "/" + remaining.map(it => encodeURIComponent(it)).join("/")
+      : components.map(it => encodeURIComponent(it)).join("/")
+    return new HistoryLocation(path, components)
+  }
+}
+
+export interface HistoryLocationWithId {
+  readonly id: string
+  readonly location: HistoryLocation
+}
+
+export interface History {
+  readonly location$: Readable<HistoryLocationWithId>
+  navigate(location: HistoryLocation, replace: boolean): void
+  getHref(location: HistoryLocation): string
+}
+
+export class HashHistory implements History {
+  readonly location$ = writable(this.getLocationFromWindow(), () => {
+    const popStateListener = () => {
+      this.onPopState()
+    }
+    window.addEventListener("popstate", popStateListener)
+    return () => {
+      window.removeEventListener("popstate", popStateListener)
+    }
+  })
+  
+  private getLocationFromWindow(): HistoryLocationWithId {
+    const id = window.history.state?.id ?? "initial"
+    const hash = window.location.hash
+    const location = (hash !== "") ? HistoryLocation.fromPath(hash.substring(1)) : HistoryLocation.fromPath("/")
+    return {
+      id,
+      location,
+    }
+  }
+  
+  private onPopState() {
+    this.location$.set(this.getLocationFromWindow())
+  }
+  
+  navigate(location: HistoryLocation, replace: boolean) {
+    const path = this.getHref(location)
+    const state = {
+      id: uuidv4(),
+    }
+    try {
+      if (replace) {
+        window.history.replaceState(state, "", path)
+      } else {
+        window.history.pushState(state, "", path)
+      }
+    } catch (e) {
+      if (replace) {
+        window.location.replace(path)
+      } else {
+        window.location.assign(path)
+      }
+    }
+    
+    this.location$.set(this.getLocationFromWindow())
+  }
+  
+  getHref(location: HistoryLocation): string {
+    return "#" + location.path
+  }
+}

--- a/src/lib/scene/invalid/Invalid.svelte
+++ b/src/lib/scene/invalid/Invalid.svelte
@@ -1,5 +1,5 @@
 <!--
-NavBar.svelte
+Invalid.svelte
 
 Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
 
@@ -23,29 +23,17 @@ THE SOFTWARE.
 -->
 
 <script lang="ts">
-  import { AppContext } from "../AppContext"
   import { getContext } from "svelte"
-  import { WatchingScene } from "./scene/watching/WatchingScene"
-  import DayChanger from "./scene/watching/DayChanger.svelte"
-  import HistoryLink from "./ui-component/HistoryLink.svelte"
+  import { AppContext } from "../../../AppContext"
+  import { InvalidScene } from "./InvalidScene"
 
   const appContext = getContext<AppContext>(AppContext.Key)
-  const watchingScene$ = appContext.sceneAs$(WatchingScene)
+  const scene$ = appContext.sceneAs$(InvalidScene)
+  $: scene = $scene$
   
-  let title: string | undefined
-  $: title = $watchingScene$?.workspace.name
+  let message: string
+  $: message = scene?.message ?? ""
 </script>
 
-<div class="px-4 bg-black border-b-2 border-b-gray-900 flex items-center h-[6rem] shrink-0">
-  <div class="flex flex-col space-y-1">
-    <HistoryLink to="/" let:href let:onClick>
-      <a href={href} on:click={onClick}><p class="text-lg font-medium">Moltonf</p></a>
-    </HistoryLink>
-  </div>
-  <div class="ml-4 grow flex flex-col items-start space-y-1">
-  {#if $watchingScene$ !== undefined}
-      <p class="text-lg font-medium">{title ?? ""}</p>
-      <DayChanger/>
-  {/if}
-  </div>
-</div>
+<!-- TODO: ちゃんとしたデザインにする -->
+<span>{message}</span>

--- a/src/lib/scene/invalid/InvalidScene.ts
+++ b/src/lib/scene/invalid/InvalidScene.ts
@@ -1,5 +1,5 @@
 //
-// SelectWorkspaceScene.ts
+// InvalidScene.ts
 //
 // Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
 //
@@ -22,33 +22,13 @@
 // THE SOFTWARE.
 //
 
-import type { AppContext } from "../../../AppContext"
 import { Scene } from "../../../Scene"
-import { type Readable, writable } from "svelte/store"
-import type { Workspace } from "../../workspace/Workspace"
-import { HistoryLocation } from "../../../History"
+import { AppContext } from "../../../AppContext"
 
-export class SelectWorkspaceScene extends Scene {
-  constructor(appContext: AppContext) {
+export class InvalidScene extends Scene {
+  readonly message: string
+  constructor(appContext: AppContext, message: string) {
     super(appContext)
-    void this.reloadWorkspaces()
-  }
-  
-  private _workspaces$ = writable<Workspace[] | undefined>(undefined)
-  get workspaces$(): Readable<Workspace[] | undefined> { return this._workspaces$ }
-  
-  private async reloadWorkspaces(): Promise<void> {
-    const workspaceStore = await this.appContext.getWorkspaceStore()
-    this._workspaces$.set(await workspaceStore.getWorkspaces())
-  }
-  
-  createNewWorkspace() {
-    this.appContext.history.navigate(HistoryLocation.fromPath("/new"), false)
-  }
-  
-  async deleteWorkspace(workspace: Workspace) {
-    const workspaceStore = await this.appContext.getWorkspaceStore()
-    await workspaceStore.remove(workspace)
-    this._workspaces$.set(await workspaceStore.getWorkspaces())
+    this.message = message
   }
 }

--- a/src/lib/scene/new-workspace/NewWorkspaceScene.ts
+++ b/src/lib/scene/new-workspace/NewWorkspaceScene.ts
@@ -25,13 +25,12 @@
 import { type AppContext } from "../../../AppContext"
 import { Scene } from "../../../Scene"
 import { derived, type Readable, type Writable, writable } from "svelte/store"
-import { WatchingScene } from "../watching/WatchingScene"
 import type { Story } from "../../story/Story"
-import { SelectWorkspaceScene } from "../select-workspace/SelectWorkspaceScene"
 import { currentValueWritable } from "../../CurrentValueStore"
 import type { Character, CharacterMap } from "../../story/CharacterMap"
 import { createCharacterMap } from "../../story/CharacterMap"
 import { type Role, Roles } from "../../story/Role"
+import { HistoryLocation } from "../../../History"
 
 export class NewWorkspaceScene extends Scene {
   constructor(appContext: AppContext) {
@@ -51,7 +50,7 @@ export class NewWorkspaceScene extends Scene {
   //#region Select Story
 
   backFromSelectStoryStep() {
-    this.appContext.changeScene(new SelectWorkspaceScene(this.appContext))
+    this.appContext.history.navigate(HistoryLocation.fromPath("/"), false)
   }
 
   get story$(): Readable<Story | undefined> { return this._story$ }
@@ -301,8 +300,7 @@ export class NewWorkspaceScene extends Scene {
       lastModified: new Date(),
     }
     const workspace = await workspaceStore.add(story, workspaceData)
-
-    this.appContext.changeScene(new WatchingScene(this.appContext, workspace))
+    this.appContext.history.navigate(HistoryLocation.fromComponents(["/", workspace.id]), true)
   }
 
   private pickCharacter(): Character | undefined {

--- a/src/lib/scene/select-workspace/SelectWorkspace.svelte
+++ b/src/lib/scene/select-workspace/SelectWorkspace.svelte
@@ -32,6 +32,8 @@ THE SOFTWARE.
   import DeleteIcon from "../../icon/DeleteIcon.svelte"
   import { readable, type Readable } from "svelte/store"
   import type { Workspace } from "../../workspace/Workspace"
+  import { HistoryLocation } from "../../../History"
+  import HistoryLink from "../../ui-component/HistoryLink.svelte"
 
   const appContext = getContext<AppContext>(AppContext.Key)
   const scene$ = appContext.sceneAs$(SelectWorkspaceScene)
@@ -102,16 +104,19 @@ THE SOFTWARE.
           
           <Listgroup class="mt-4" active>
             {#each $workspaces$ as item (item.id)}
-              <ListgroupItem on:click={() => scene?.selectWorkspace(item)}> 
-                <div class="flex items-center justify-between w-full">
-                  <div class="inline-flex">
-                    <WorkspaceIcon size="1.25rem" class="mr-2"/>{item.name}
+              {@const location = HistoryLocation.fromComponents(["/", item.id])}
+              <HistoryLink to={location} let:href let:onClick>
+                <ListgroupItem href={href} on:click={onClick}> 
+                  <div class="flex items-center justify-between w-full">
+                    <div class="inline-flex">
+                      <WorkspaceIcon size="1.25rem" class="mr-2"/>{item.name}
+                    </div>
+                    <button class="hover:text-red-500" on:click|preventDefault|stopPropagation={() => void deleteWorkspace(item)}>
+                      <DeleteIcon size="1.25rem"/>
+                    </button>
                   </div>
-                  <button class="hover:text-red-500" on:click|stopPropagation={() => void deleteWorkspace(item)}>
-                    <DeleteIcon size="1.25rem"/>
-                  </button>
-                </div>
-              </ListgroupItem>
+                </ListgroupItem>
+              </HistoryLink>
             {/each}
           </Listgroup>
           <div class="flex justify-end">

--- a/src/lib/scene/watching/DayChanger.svelte
+++ b/src/lib/scene/watching/DayChanger.svelte
@@ -28,6 +28,7 @@ THE SOFTWARE.
   import { AppContext } from "../../../AppContext"
   import { type WatchableDay, WatchingScene } from "./WatchingScene"
   import { type Readable, readable } from "svelte/store"
+  import HistoryLink from "../../ui-component/HistoryLink.svelte"
 
   const appContext = getContext<AppContext>(AppContext.Key)
   const scene$ = appContext.sceneAs$(WatchingScene)
@@ -40,10 +41,14 @@ THE SOFTWARE.
   $: currentDay$ = scene?.currentDay$ ?? readable(0)
 </script>
 
-<ButtonGroup class="overflow-x-auto">
-  {#each $watchableDays$ as wday}
-    <Button size="xs" color="red" class="shrink-0" on:click={() => scene?.changeCurrentDay(wday.day)} outline={wday.day !== $currentDay$}>
-      {wday.text}
-    </Button>
-  {/each}
-</ButtonGroup>
+{#if scene !== undefined}
+  <ButtonGroup class="overflow-x-auto">
+    {#each $watchableDays$ as wday}
+      <HistoryLink to={scene.getLocation(wday.day)} let:href let:onClick>
+        <Button size="xs" color="red" class="shrink-0" href={href} on:click={onClick} outline={wday.day !== $currentDay$}>
+          {wday.text}
+        </Button>
+      </HistoryLink>
+    {/each}
+  </ButtonGroup>
+{/if}

--- a/src/lib/scene/watching/Watching.svelte
+++ b/src/lib/scene/watching/Watching.svelte
@@ -50,14 +50,6 @@ THE SOFTWARE.
   
   let scroller = undefined as HTMLDivElement | undefined
   
-  function getElementIdByScrollPosition(): string | undefined {
-    if (scroller === undefined) {
-      return undefined
-    }
-    const yPosition = scroller.getBoundingClientRect().top
-    return watchingContext.getElementIdByYPosition(yPosition)
-  }
-  
   let currentDay$: Readable<number>
   $: currentDay$ = scene?.currentDay$ ?? readable(-1)
   let currentDay: number

--- a/src/lib/scene/watching/Watching.svelte
+++ b/src/lib/scene/watching/Watching.svelte
@@ -23,39 +23,89 @@ THE SOFTWARE.
 -->
 
 <script lang="ts">
-  import { getContext } from "svelte"
+  import { getContext, onDestroy, setContext } from "svelte"
   import { AppContext } from "../../../AppContext"
   import { WatchingScene } from "./WatchingScene"
   import type { Readable } from "svelte/store"
-  import type { Story } from "../../story/Story"
   import { readable } from "svelte/store"
+  import type { Story } from "../../story/Story"
   import { Button, Spinner } from "flowbite-svelte"
   import WatchingElementsView from "./WatchingElementsView.svelte"
-  
+  import { WatchingContext } from "./WatchingContext"
+
   const unreactives = {
     lastCurrentDay: -1,
+    scrollTimer: undefined as number | undefined,
   }
 
   const appContext = getContext<AppContext>(AppContext.Key)
   const scene$ = appContext.sceneAs$(WatchingScene)
   $: scene = $scene$
 
+  const watchingContext = new WatchingContext()
+  setContext(WatchingContext.Key, watchingContext)
+  
   let story$: Readable<Story | undefined>
   $: story$ = scene?.story$ ?? readable(undefined)
   
-  let scroller: HTMLDivElement
+  let scroller = undefined as HTMLDivElement | undefined
+  
+  function getElementIdByScrollPosition(): string | undefined {
+    if (scroller === undefined) {
+      return undefined
+    }
+    const yPosition = scroller.getBoundingClientRect().top
+    return watchingContext.getElementIdByYPosition(yPosition)
+  }
+  
   let currentDay$: Readable<number>
   $: currentDay$ = scene?.currentDay$ ?? readable(-1)
+  let currentDay: number
   $: {
+    currentDay = $currentDay$
+    
     // If current day has been changed, reset the scroll position to top. 
-    if ($currentDay$ !== unreactives.lastCurrentDay) {
-      unreactives.lastCurrentDay = $currentDay$
-      scroller?.scrollTo(0, 0)
+    if (currentDay !== unreactives.lastCurrentDay) {
+      unreactives.lastCurrentDay = currentDay
+      if (scroller !== undefined) {
+        scroller.scrollTo(0, 0)
+      }
+    }
+  }
+
+  let focusedElementId$: Readable<string | undefined>
+  $: focusedElementId$ = scene?.focusedElementId$ ?? readable(undefined)
+  $: {
+    const focusedElementId = $focusedElementId$
+    if (focusedElementId !== undefined) {
+      if (unreactives.scrollTimer !== undefined) {
+        window.clearTimeout(unreactives.scrollTimer)
+      }
+      unreactives.scrollTimer = window.setTimeout(() => {
+        unreactives.scrollTimer = undefined
+        watchingContext.scrollToElement(focusedElementId)
+        const location = scene?.getLocation(currentDay)
+        if (location !== undefined) {
+          appContext.history.navigate(location, true)
+        }
+      }, 200)
     }
   }
   
   let canMoveToNextDay$: Readable<boolean>
   $: canMoveToNextDay$ = scene?.canMoveToNextDay$ ?? readable(false)
+  
+  let moveToNextDay$: Readable<() => void>
+  $: moveToNextDay$ = scene?.moveToNextDay$ ?? readable(() => { /* do nothing */ })
+  function moveToNextDay() {
+    ($moveToNextDay$)()
+  }
+
+  onDestroy(() => {
+    if (unreactives.scrollTimer !== undefined) {
+      clearTimeout(unreactives.scrollTimer)
+    }
+  })
 </script>
 
 {#if $story$ === undefined}
@@ -69,7 +119,7 @@ THE SOFTWARE.
         <div class="bg-black text-sm max-w-[600px] p-6 rounded-md">
           <WatchingElementsView/>
           {#if $canMoveToNextDay$}
-            <Button color="red" class="mt-4" on:click={() => scene?.moveToNextDay()}>次の日へ</Button>
+            <Button color="red" class="mt-4" on:click={() => moveToNextDay()}>次の日へ</Button>
           {/if}
         </div>
       </div>

--- a/src/lib/scene/watching/WatchingContext.ts
+++ b/src/lib/scene/watching/WatchingContext.ts
@@ -35,23 +35,6 @@ export class WatchingContext {
     this._elementMap.delete(id)
   }
 
-  getElementIdByYPosition(yPosition: number): string | undefined {
-    let result: string | undefined = undefined
-    let maxTop = Number.NEGATIVE_INFINITY
-    
-    for (const [id, element] of this._elementMap.entries()) {
-      const rect = element.getBoundingClientRect()
-      if (rect.top <= yPosition) {
-        const top = rect.top
-        if (top > maxTop) {
-          result = id
-          maxTop = top
-        }
-      }
-    }
-    return result
-  }
-  
   scrollToElement(id: string) {
     const elem = this._elementMap.get(id)
     if (elem !== undefined) {

--- a/src/lib/scene/watching/WatchingContext.ts
+++ b/src/lib/scene/watching/WatchingContext.ts
@@ -1,0 +1,61 @@
+//
+// WatchingContext.ts
+//
+// Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+export class WatchingContext {
+  static readonly Key = Symbol()
+
+  private _elementMap = new Map<string, HTMLElement>()
+
+  addElement(id: string, elem: HTMLElement) {
+    this._elementMap.set(id, elem)
+  }
+
+  removeElement(id: string) {
+    this._elementMap.delete(id)
+  }
+
+  getElementIdByYPosition(yPosition: number): string | undefined {
+    let result: string | undefined = undefined
+    let maxTop = Number.NEGATIVE_INFINITY
+    
+    for (const [id, element] of this._elementMap.entries()) {
+      const rect = element.getBoundingClientRect()
+      if (rect.top <= yPosition) {
+        const top = rect.top
+        if (top > maxTop) {
+          result = id
+          maxTop = top
+        }
+      }
+    }
+    return result
+  }
+  
+  scrollToElement(id: string) {
+    const elem = this._elementMap.get(id)
+    if (elem !== undefined) {
+      elem.scrollIntoView()
+    }
+  }
+}

--- a/src/lib/scene/watching/WatchingElementView.svelte
+++ b/src/lib/scene/watching/WatchingElementView.svelte
@@ -1,0 +1,100 @@
+<!--
+WatchingElementView.svelte
+
+Copyright (c) 2023 Hironori Ichimiya <hiron@hironytic.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<script lang="ts">
+  import type { CharacterMap } from "../../story/CharacterMap"
+  import type { WatchingElement } from "./WatchingScene"
+  import { MoltonfMessageType } from "./WatchingScene"
+  import { StoryElementTypes } from "../../story/StoryElement"
+  import { EventNames } from "../../story/StoryEventName"
+  import TalkView from "./TalkView.svelte"
+  import { TalkTypes } from "../../story/TalkType"
+  import StoryEventView from "./StoryEventView.svelte"
+  import MoltonfMessageView from "./MoltonfMessageView.svelte"
+  import { getContext, onMount } from "svelte"
+  import { WatchingContext } from "./WatchingContext"
+
+  const watchingContext = getContext<WatchingContext>(WatchingContext.Key)
+  
+  export let characterMap: CharacterMap = new Map()
+  export let faceIconUrlMap: Map<string | symbol, string> = new Map()
+  export let element = {
+    elementId: "",
+    elementType: MoltonfMessageType,
+    messageLines: [],
+  } as WatchingElement
+  
+  let elementDiv = undefined as HTMLDivElement | undefined
+  
+  function registerElement(elementId: string) {
+    if (elementDiv !== undefined) {
+      if (unreactives.lastElementId !== elementId) {
+        if (unreactives.lastElementId !== undefined) {
+          watchingContext.removeElement(unreactives.lastElementId)
+        }
+        unreactives.lastElementId = elementId
+        watchingContext.addElement(elementId, elementDiv)
+      }
+    }
+  }
+  
+  const unreactives = {
+    lastElementId: undefined as string | undefined,
+  }
+  
+  $: registerElement(element.elementId)
+  
+  onMount(() => {
+    registerElement(element.elementId)
+    return () => {
+      if (unreactives.lastElementId !== undefined) {
+        watchingContext.removeElement(unreactives.lastElementId)
+      }
+    }
+  })
+</script>
+
+<div class="mb-4" bind:this={elementDiv}>
+  {#if element.elementType === StoryElementTypes.TALK}
+    <TalkView talk={element} {characterMap} {faceIconUrlMap}/>
+  {:else if element.elementType === StoryElementTypes.STORY_EVENT}
+    {#if element.eventName === EventNames.ASSAULT}
+      <!-- Handle special case: ASSAULT is displayed as Wolf's Talk -->
+      <TalkView talk={{
+            elementId: element.elementId,
+            elementType: StoryElementTypes.TALK,
+            talkType: TalkTypes.WOLF,
+            avatarId: element.byWhom,
+            xname: element.xname,
+            time: element.time,
+            talkNo: undefined,
+            messageLines: element.messageLines
+          }} {characterMap} {faceIconUrlMap}/>
+    {:else}
+      <StoryEventView storyEvent={element}/>
+    {/if}
+  {:else if element.elementType === MoltonfMessageType}
+    <MoltonfMessageView message={element}/>
+  {/if}
+</div>

--- a/src/lib/scene/watching/WatchingElementsView.svelte
+++ b/src/lib/scene/watching/WatchingElementsView.svelte
@@ -25,16 +25,11 @@ THE SOFTWARE.
 <script lang="ts">
   import { getContext } from "svelte"
   import { AppContext } from "../../../AppContext"
-  import { MoltonfMessageType, WatchingScene } from "./WatchingScene"
+  import { WatchingScene } from "./WatchingScene"
   import { readable, type Readable } from "svelte/store"
-  import { StoryElementTypes } from "../../story/StoryElement"
-  import StoryEventView from "./StoryEventView.svelte"
-  import TalkView from "./TalkView.svelte"
-  import { EventNames } from "../../story/StoryEventName"
-  import { TalkTypes } from "../../story/TalkType"
   import type { CharacterMap } from "../../story/CharacterMap"
   import type { WatchingElement } from "./WatchingScene.js"
-  import MoltonfMessageView from "./MoltonfMessageView.svelte"
+  import WatchingElementView from "./WatchingElementView.svelte"
 
   const appContext = getContext<AppContext>(AppContext.Key)
   const scene$ = appContext.sceneAs$(WatchingScene)
@@ -51,27 +46,5 @@ THE SOFTWARE.
 </script>
 
 {#each $currentElements$ as element (element.elementId)}
-  <div class="mb-4">
-    {#if element.elementType === StoryElementTypes.TALK}
-      <TalkView talk={element} characterMap={$characterMap$} faceIconUrlMap={$faceIconUrlMap$}/>
-    {:else if element.elementType === StoryElementTypes.STORY_EVENT}
-      {#if element.eventName === EventNames.ASSAULT}
-        <!-- Handle special case: ASSAULT is displayed as Wolf's Talk -->
-        <TalkView talk={{
-          elementId: element.elementId,
-          elementType: StoryElementTypes.TALK,
-          talkType: TalkTypes.WOLF,
-          avatarId: element.byWhom,
-          xname: element.xname,
-          time: element.time,
-          talkNo: undefined,
-          messageLines: element.messageLines
-        }} characterMap={$characterMap$} faceIconUrlMap={$faceIconUrlMap$}/>
-      {:else}
-        <StoryEventView storyEvent={element}/>
-      {/if}
-    {:else if element.elementType === MoltonfMessageType}
-      <MoltonfMessageView message={element}/>
-    {/if}
-  </div>
+  <WatchingElementView element={element} characterMap={$characterMap$} faceIconUrlMap={$faceIconUrlMap$}/>
 {/each}

--- a/src/lib/storage/MoltonfDB.ts
+++ b/src/lib/storage/MoltonfDB.ts
@@ -45,7 +45,7 @@ export interface MoltonfDB extends DBSchema {
   }
 
   workspaces: {
-    key: number
+    key: string
     value: Workspace
     indexes: { "lastModified": Date }
   }
@@ -56,7 +56,7 @@ export async function openMoltonfDB(): Promise<IDBPDatabase<MoltonfDB>> {
     upgrade(database: IDBPDatabase<MoltonfDB>) {
       database.createObjectStore(StoreNames.STORIES, { autoIncrement: true })
       
-      const workspacesStore = database.createObjectStore(StoreNames.WORKSPACES, { keyPath: "id", autoIncrement: true })
+      const workspacesStore = database.createObjectStore(StoreNames.WORKSPACES, { keyPath: "id" })
       workspacesStore.createIndex(IndexNames.WORKSPACES.LAST_MODIFIED, "lastModified", { unique: false })
     }
   })

--- a/src/lib/story/Archive.ts
+++ b/src/lib/story/Archive.ts
@@ -49,12 +49,13 @@ import { EventNames } from "./StoryEventName"
 import type { Player } from "./Player"
 import { TalkTypes } from "./TalkType"
 import type { Role } from "./Role"
+import { v4 as uuid } from 'uuid'
 
 export async function loadStoryFromArchiveFile(file: File): Promise<Story> {
   const xml = await readFileAsText(file)
   const parser = new DOMParser()
   const document = parser.parseFromString(xml, "text/xml")
-  return parseArciveDocument(document)
+  return parseArchiveDocument(document)
 }
 
 export class InvalidArchiveError extends Error {
@@ -85,9 +86,7 @@ async function readFileAsText(file: File): Promise<string> {
   })
 }
 
-function parseArciveDocument(document: XMLDocument): Story {
-  let currentDay = 0
-  let currentElementIndex = 0
+function parseArchiveDocument(document: XMLDocument): Story {
   let currentElementId = ""
   let publicTalkCount = 0
 
@@ -209,16 +208,12 @@ function parseArciveDocument(document: XMLDocument): Story {
     const type = getAttributeOrError(periodElem, "type")
     const day = parseInt(getAttributeOrError(periodElem, "day"), 10)
     
-    currentDay = day
-    currentElementIndex = 0
-    
     const elements: StoryElement[] = []
     const children = periodElem.children
     for (const child of children) {
       const storyElement = parseStoryElement(child)
       if (storyElement !== undefined) {
         elements.push(storyElement)
-        currentElementIndex++
       }
     }
     
@@ -230,7 +225,7 @@ function parseArciveDocument(document: XMLDocument): Story {
   }
   
   function parseStoryElement(elementElem: Element): StoryElement | undefined {
-    currentElementId = `${currentDay}/${currentElementIndex}`
+    currentElementId = uuid()
     
     const name = elementElem.tagName
     switch (name) {

--- a/src/lib/workspace/Workspace.ts
+++ b/src/lib/workspace/Workspace.ts
@@ -24,7 +24,7 @@
 
 export interface Workspace {
   /** Workspace ID */
-  id: number
+  id: string
   
   /** Name of this workspace */
   name: string


### PR DESCRIPTION
Introduced hash based URL routing.

| URL                                   | Description                                  |
|---------------------------------------|----------------------------------------------|
| `#/`                                  | Select workspaces (`SelectWorkspaceScene`)   |
| `#/new`                               | Create a new workspace (`NewWorkspaceScene`) |
| `#/<workspace-id>`                    | Watching a workspace (`WatchingScene`)       |
| `#/<workspace-id>/<day>`              | Watching on specified day                    |
| `#/<workspace-id>/<day>/<element-id>` | Will scroll to specified element             |

This enables user to open different day on another browser tab.
Also, this is useful for linking to talks. (#54)
