### PR TITLE
Fix base path to "/moltonf-web/app/"

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  base: "/app/",
+  base: "/moltonf-web/app/",
   build: {
     outDir: "dist/app"
   },


### PR DESCRIPTION
The app site URL on GitHub Pages seems to be https://hironytic.github.io/moltonf-web/app/
This PR fixes the base path from "/app" to "/moltonf-web/app".
