### PR TITLE
Fix link to "Jindolf XML Scheme"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Works with JavaScript within your browser. The logs you select and watching stat
 
 ### The logs are XML files
 
-The logs are XML files in the Common Archive Format of Jinro BBS. You need to obtain the log that you wish to watch in advance.
+The logs are XML files that structures are defined as "[Jindolf XML Scheme](https://osdn.net/projects/jindolf/scm/git/XmlScheme)". You need to obtain the log that you wish to watch in advance.
 
 ## How to run
 

--- a/docs/ArchiveSchema/LICENSE.txt
+++ b/docs/ArchiveSchema/LICENSE.txt
@@ -1,0 +1,33 @@
+[UTF-8 Japanese]
+
+The MIT License
+
+
+Copyright(c) 2009 olyutorskii
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+作者自身からのコメント：
+
+  ※ 少なくともこのソフトウェアの実行、複製、配布、改造は自由です。
+  ※ 少なくともこのソフトウェアは無保証です。
+
+--- EOF ---

--- a/site/index.html
+++ b/site/index.html
@@ -56,7 +56,7 @@
                 </div>
 
                 <div class="text-base ml-4 mt-4">
-                  <p>過去ログとして<a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="https://wolfbbs.jp/%B6%A6%C4%CC%A5%A2%A1%BC%A5%AB%A5%A4%A5%D6%B4%F0%C8%D7%C0%B0%C8%F7%B7%D7%B2%E8.html" target="_blank" rel="noopener noreferrer">共通アーカイブ <svg xmlns="http://www.w3.org/2000/svg" height="0.8rem" viewBox="0 0 24 24" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg></a>（※2023/06/28時点ではサイトに接続できません）形式のXMLファイルを使います。あらかじめ観戦したい過去ログを入手しておいていただく必要があります。</p>
+                  <p>過去ログとして<a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="https://osdn.net/projects/jindolf/scm/git/XmlScheme" target="_blank" rel="noopener noreferrer">Jindolf XML Scheme <svg xmlns="http://www.w3.org/2000/svg" height="0.8rem" viewBox="0 0 24 24" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg></a>形式のXMLファイルを使います。あらかじめ観戦したい過去ログを入手しておいていただく必要があります。</p>
                 </div>
 
                 <div class="flex items-center space-x-2 text-xl font-bold text-gray-300 mt-4">
@@ -77,8 +77,8 @@
                 </div>
 
                 <div class="text-base ml-4 mt-4">
-                  <p>観戦には共通アーカイブ形式のXMLファイルが必要になります。あらかじめ誰かからデータをもらうなり、自分で作成するなりして入手しておいてください。</p>
-                  <p class="mt-2">人狼BBS用の専用クライアント「<a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="http://jindolf.osdn.jp/" target="_blank" rel="noopener noreferrer">Jindolf <svg xmlns="http://www.w3.org/2000/svg" height="0.8rem" viewBox="0 0 24 24" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg></a>」の作者であり、共通アーカイブ形式の提唱者でもある olyutorskii さんが開発された「JinArchiver」を使うと、人狼BBSから指定した村データをダウンロードして共通アーカイブ形式で保存できます。</p>
+                  <p>観戦にはJindolf XML Scheme形式のXMLファイルが必要になります。あらかじめ誰かからデータをもらうなり、自分で作成するなりして入手しておいてください。</p>
+                  <p class="mt-2">人狼BBS用の専用クライアント「<a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="http://jindolf.osdn.jp/" target="_blank" rel="noopener noreferrer">Jindolf <svg xmlns="http://www.w3.org/2000/svg" height="0.8rem" viewBox="0 0 24 24" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg></a>」の作者であり、Jindolf XML Scheme形式の提唱者でもある olyutorskii さんが開発された「JinArchiver」を使うと、人狼BBSから指定した村データをダウンロードしてJindolf XML Scheme形式で保存できます。</p>
                   <ul class="ml-8 mt-6 list-disc list-outside">
                     <li><a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="https://osdn.net/projects/jindolf/releases/p10174" target="_blank" rel="noopener noreferrer">JinArchiver <svg xmlns="http://www.w3.org/2000/svg" height="0.8rem" viewBox="0 0 24 24" fill="currentColor"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"/></svg></a></li>
                   </ul>

--- a/src/lib/scene/new-workspace/SelectStory.svelte
+++ b/src/lib/scene/new-workspace/SelectStory.svelte
@@ -78,7 +78,7 @@ THE SOFTWARE.
     
       <div class="text-sm mt-4">
         <p>
-          <a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="https://wolfbbs.jp/%B6%A6%C4%CC%A5%A2%A1%BC%A5%AB%A5%A4%A5%D6%B4%F0%C8%D7%C0%B0%C8%F7%B7%D7%B2%E8.html" target="_blank" rel="noopener noreferrer">人狼BBSの共通アーカイブ<ExternalSiteIcon size="0.8rem"/></a>形式のXMLファイルを用意してください。
+          <a class="text-red-500 underline hover:text-gray-300 inline-flex items-baseline" href="https://osdn.net/projects/jindolf/scm/git/XmlScheme" target="_blank" rel="noopener noreferrer">Jindolf XML Scheme <ExternalSiteIcon size="0.8rem"/></a>形式のXMLファイルを用意してください。
           そのXMLファイルの村データを読み込みます。
           読み込んだデータはブラウザが管理するローカルコンピューター上のストレージに保存されます
           （観戦データが作成された後は、ここで選択したXMLファイルはもう参照しません）。


### PR DESCRIPTION
Due to the closure of "人狼BBS まとめサイト", I changed the site that linked from this app.

It was: "[共通アーカイブ基盤整備計画](http://wolfbbs.jp/%B6%A6%C4%CC%A5%A2%A1%BC%A5%AB%A5%A4%A5%D6%B4%F0%C8%D7%C0%B0%C8%F7%B7%D7%B2%E8.html)"
Now changed to: "[Jindolf XML Scheme](https://osdn.net/projects/jindolf/scm/git/XmlScheme)"
