### PR TITLE
Fix overflow-wrap

### DIFF
--- a/src/lib/scene/watching/MoltonfMessageView.svelte
+++ b/src/lib/scene/watching/MoltonfMessageView.svelte
@@ -48,6 +48,7 @@ THE SOFTWARE.
 <style>
   .message {
     font-family: "sans-serif";
+    overflow-wrap: anywhere;
   }
   
   .ef-moltonf {

--- a/src/lib/scene/watching/StoryEventView.svelte
+++ b/src/lib/scene/watching/StoryEventView.svelte
@@ -52,6 +52,7 @@ THE SOFTWARE.
 <style>
   .message {
     font-family: "sans-serif";
+    overflow-wrap: anywhere;
   }
   
   .ef-announce {

--- a/src/lib/scene/watching/TalkView.svelte
+++ b/src/lib/scene/watching/TalkView.svelte
@@ -130,6 +130,7 @@ THE SOFTWARE.
 <style>
   .message {
     font-family: "sans-serif";
+    overflow-wrap: anywhere;
   }
   
   .avatar-name {


### PR DESCRIPTION
fixes #113 

Fix that message sometimes overflows.

| Before | After |
|-----|-----|
| <img width="350" alt="overflow" src="https://github.com/hironytic/moltonf-web/assets/1498691/06cfadb1-0c0f-431a-86c4-05168b26956a"> | <img width="350" alt="fix" src="https://github.com/hironytic/moltonf-web/assets/1498691/4fe37c14-677d-4f77-9044-670f15e70817"> |

