### PR TITLE
Dependabot grouped update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -24,5 +25,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      semver-patch:
+        update-types:
+          - "patch"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
   
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Defines dependabot groups below:

- `semver-patch`: contains patch level updates.
- `typescript-eslint`: contains `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin`.

Also change schedule.interval to weekly.