### PR TITLE
Fix: dead wolf cannot hear whispers (#227)

### DIFF
--- a/src/lib/scene/watching/CurrentElements.test.ts
+++ b/src/lib/scene/watching/CurrentElements.test.ts
@@ -571,9 +571,14 @@ describe("CurrentElements", () => {
         expect(elements.find(it => it.elementId === "BB770850-7822-498D-B528-32CE1949DA08")).toBeUndefined()
       })
 
-      it("should show a wolf's talk", () => {
+      it("should show a wolf's talk if player character is alive", () => {
         const elements = currentElements(story, createCharacterMap(story), "liesa", 3, 3)
         expect(elements.find(it => it.elementId === "F720D764-05CC-4CBD-8ECC-69185C59EAE8")).toBeDefined()
+      })
+
+      it("should hide a wolf's talk if player character is dead", () => {
+        const elements = currentElements(story, createCharacterMap(story), "simson", 3, 3)
+        expect(elements.find(it => it.elementId === "F720D764-05CC-4CBD-8ECC-69185C59EAE8")).toBeUndefined()
       })
     })
 

--- a/src/lib/scene/watching/CurrentElements.ts
+++ b/src/lib/scene/watching/CurrentElements.ts
@@ -75,7 +75,7 @@ function filterStoryElement(story: Story, characterMap: CharacterMap, dayProgres
         case TalkTypes.PRIVATE:
           return filter(isPrivateTalkVisible(element, character))
         case TalkTypes.WOLF:
-          return filter(isWolfTalkVisible(story, character))
+          return filter(isWolfTalkVisible(story, character, currentDay))
         case TalkTypes.GRAVE:
           return filter(isGraveTalkVisible(character, currentDay))
         default:
@@ -119,7 +119,7 @@ function filterStoryElement(story: Story, characterMap: CharacterMap, dayProgres
         case EventNames.ASSAULT:
         {
           return filter(
-            isAssaultVisible(character),
+            isAssaultVisible(story, character, currentDay),
           )
         }
         default:
@@ -146,7 +146,7 @@ export function isTalkVisible(story: Story, day: number, talk: Talk, character: 
     case TalkTypes.PRIVATE:
       return isPrivateTalkVisible(talk, character)
     case TalkTypes.WOLF:
-      return isWolfTalkVisible(story, character)
+      return isWolfTalkVisible(story, character, day)
     case TalkTypes.GRAVE:
       return isGraveTalkVisible(character, day)
     default:
@@ -162,8 +162,8 @@ function isPrivateTalkVisible(talk: Talk, character: Character): boolean {
   return talk.avatarId === character.avatar.avatarId
 }
 
-function isWolfTalkVisible(story: Story, character: Character): boolean {
-  return character.role === Roles.WOLF
+function isWolfTalkVisible(story: Story, character: Character, currentDay: number): boolean {
+  return (character.role === Roles.WOLF && character.aliveUntil >= currentDay)
     || (story.landId === "wolfc" && character.role === Roles.MADMAN)
 }
 
@@ -183,8 +183,8 @@ function isCounting2Visible(): boolean {
   return false
 }
 
-function isAssaultVisible(character: Character): boolean {
-  return character.role === Roles.WOLF
+function isAssaultVisible(story: Story, character: Character, currentDay: number): boolean {
+  return isWolfTalkVisible(story, character, currentDay)
 }
 
 function createPlayerCharacterMessage(idBase: string, character: Character, characterMap: CharacterMap): MoltonfMessage {


### PR DESCRIPTION
fixes #227

- After executed, the wolf cannot hear whispers of companions.
- After reached the epilogue, he/she can see them.
- Fix also `isAssaultVisible()`.